### PR TITLE
fix-pagination-observationunits

### DIFF
--- a/api/observationunits.py
+++ b/api/observationunits.py
@@ -79,12 +79,10 @@ def search(germplasmDbId=None, observationVariableDbId=None, studyDbId=None, loc
     data = _conform_data([dict(r) for r in res])
 
     # split data if needed, remembering total number
-    count = len(data)
     if not pageSize:
         pageSize = helper.DEFAULT_PAGE_SIZE
     if not page:
         page = 0
-    data = data[page * pageSize:(page+1) * pageSize]
 
     return helper.create_result({"data": data}, count, pageSize, page)
 


### PR DESCRIPTION
the observation units endpoint always had the pageSize as the total count, and the totalPages was always 1 because of this error. 

The count was overwritten to be the size of the result returned for the requested page.